### PR TITLE
check for Version produces an error

### DIFF
--- a/Essbase.py
+++ b/Essbase.py
@@ -181,7 +181,7 @@ class Essbase:
         __maxldll = find_library('essmaxlu')
         if __maxldll:
             print ("Using Maxl DLL in {DLLpath}".format(DLLpath = __maxldll))
-            if "11.1.2.4" in (getFileVerInfo(__maxldll)):
+            if b"11.1.2.4" in (getFileVerInfo(__maxldll)):
                 MAXL_MDXCELLSTRSZ           = 1024 + 3
             else:
                 MAXL_MDXCELLSTRSZ           = 1024


### PR DESCRIPTION
if "11.1.2.4" in (getFileVerInfo(__maxldll)):
TypeError: a bytes-like object is required, not 'str'

changed version string to bytes